### PR TITLE
Python3 optimizations to imports and threading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,14 +38,14 @@ Examples for thriftpy is:
 .. code:: python
 
     import thriftpy
-    from thrift_connector import ClientPool, ThriftPyCyClient
+    import thrift_connector.connection_pool as connection_pool
 
     service = thriftpy.load("pingpong_app/pingpong.thrift")
-    pool = ClientPool(
+    pool = connection_pool.ClientPool(
         service.PingService,
         'localhost',
         8880,
-        connction_class=ThriftPyCyClient
+        connction_class=connection_pool.ThriftPyCyClient
         )
 
     print "Sending Ping..."
@@ -60,13 +60,13 @@ Examples for thrift is:
     # -*- coding: utf-8 -*-
 
     from pingpong_app.pingpong_sdk.pingpong import PingService
-    from thrift_connector import ClientPool, ThriftClient
+    import connection_pool
 
-    pool = ClientPool(
+    pool = connection_pool.ClientPool(
         PingService,
         'localhost',
         8880,
-        connction_class=ThriftClient
+        connction_class=connection_pool.ThriftClient
         )
 
     print "Sending Ping..."

--- a/thrift_connector/__init__.py
+++ b/thrift_connector/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from connection_pool import ClientPool, ThriftClient, ThriftPyClient, \
+from .connection_pool import ClientPool, ThriftClient, ThriftPyClient, \
     ThriftPyCyClient, RandomMultiServerClient, RoundRobinMultiServerClient, \
     HeartbeatClientPool
 

--- a/thrift_connector/connection_pool.py
+++ b/thrift_connector/connection_pool.py
@@ -4,7 +4,7 @@ import logging
 import datetime
 import contextlib
 import random
-import thread
+import threading
 import time
 
 from .hooks import api_call_context
@@ -423,7 +423,7 @@ class HeartbeatClientPool(ClientPool):
             tracking=tracking,
             tracker_factory=tracker_factory
             )
-        thread.start_new_thread(self.maintain_connections, tuple())
+        threading.Thread(target=self.maintain_connections).start()
 
     def _close_and_remove_client(self, client):
         if client not in self.connections:


### PR DESCRIPTION
Fixed import errors and updated thread functionality in re python3(I.E: python 2.7 compatibility is gone now).