### PR TITLE
Add Tornado support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ Session.vim
 
 .ropeproject
 examples/pingpong_app/pingpong_sdk/
+examples/pingpong_app/pingpong_sdk_tornado/

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,8 @@ Examples for thrift is:
     print "Winning the match..."
     print "Receive:", pool.win()
 
+Examples for Tornado clients can be found in `examples`.
+
 Test
 ----
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 flake8==2.2.4
-gevent==1.0.1
-greenlet==0.4.4
+gevent==1.1.2
+greenlet==0.4.10
 gunicorn==19.1.1
 gunicorn-thrift==0.0.8
 mccabe==0.2.1
@@ -11,4 +11,6 @@ pytest==2.6.3
 setproctitle==1.1.8
 thrift==0.9.1
 wsgiref==0.1.2
-thriftpy==0.1.13
+thriftpy==0.3.9
+tornado==4.4.2
+toro==1.0.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -9,7 +9,7 @@ py==1.4.25
 pyflakes==0.8.1
 pytest==2.6.3
 setproctitle==1.1.8
-thrift==0.9.1
+thrift==0.9.3
 wsgiref==0.1.2
 thriftpy==0.3.9
 tornado==4.4.2

--- a/examples/gunicorn_config_framed.py
+++ b/examples/gunicorn_config_framed.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+
+worker_class = "thriftpy_gevent"
+thrift_protocol_factory = "thriftpy.protocol:TCyBinaryProtocolFactory"
+thrift_transport_factory = "thriftpy.transport:TFramedTransportFactory"
+
+errorlog = '-'

--- a/examples/pingpong_app/pingpong.thrift
+++ b/examples/pingpong_app/pingpong.thrift
@@ -11,5 +11,5 @@ service PingService {
      */
     string ping() throws (1:AboutToShutDownException shutdown_exception),
     string win(),
-    string sleep(1:i32 seconds),
+    string sleep(1:double seconds),
 }

--- a/examples/server_tornado.sh
+++ b/examples/server_tornado.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+cd pingpong_app
+mkdir -p pingpong_sdk
+thrift -out pingpong_sdk --gen py:new_style  pingpong.thrift
+mkdir -p pingpong_sdk_tornado
+thrift -out pingpong_sdk_tornado --gen py:tornado pingpong.thrift
+cd ..
+
+gunicorn_thrift pingpong_app.app:app -c gunicorn_config_framed.py --bind 0.0.0.0:8880

--- a/examples/tornado_thrift_client.py
+++ b/examples/tornado_thrift_client.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from tornado import gen
+from tornado.ioloop import IOLoop
+
+from pingpong_app.pingpong_sdk_tornado.pingpong import PingService
+from thrift_connector.tornado import TornadoClientPool, TornadoThriftClient
+
+pool = TornadoClientPool(
+    PingService,
+    'localhost',
+    8880,
+    connection_class=TornadoThriftClient
+)
+
+
+def callback(future):
+    print future.result()
+    IOLoop.current().stop()
+
+
+@gen.coroutine
+def main():
+    print "Sending Ping..."
+    print "Receive:", (yield pool.ping())
+    print "Sleeping..."
+    with (yield pool.connection_ctx()) as conn:
+        yield conn.sleep(1)
+    print "Waked!"
+    print "Winning the match..."
+    print "Receive:"
+    pool.win().add_done_callback(callback)
+
+
+IOLoop.current().add_callback(main)
+IOLoop.current().start()

--- a/examples/tornado_thriftpy_client.py
+++ b/examples/tornado_thriftpy_client.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import thriftpy
+from tornado import gen
+from tornado.ioloop import IOLoop
+
+from thrift_connector.tornado import TornadoClientPool, TornadoThriftPyClient
+
+service = thriftpy.load("pingpong_app/pingpong.thrift")
+pool = TornadoClientPool(
+    service.PingService,
+    'localhost',
+    8880,
+    connection_class=TornadoThriftPyClient
+)
+
+
+def callback(future):
+    print future.result()
+    IOLoop.current().stop()
+
+
+@gen.coroutine
+def main():
+    print "Sending Ping..."
+    print "Receive:", (yield pool.ping())
+    print "Sleeping..."
+    with (yield pool.connection_ctx()) as conn:
+        yield conn.sleep(1)
+    print "Waked!"
+    print "Winning the match..."
+    print "Receive:"
+    pool.win().add_done_callback(callback)
+
+
+IOLoop.current().add_callback(main)
+IOLoop.current().start()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -362,7 +362,7 @@ def test_heartbeat_client_pool(
         port=pingpong_thrift_client.port,
         timeout=1,
         connection_class=pingpong_thrift_client.pool.connection_class,
-        max_conn=5,
+        max_conn=3,
         check_interval=2,
     )
 
@@ -380,16 +380,18 @@ def test_heartbeat_client_pool(
     assert heartbeat_pool.put_back_connection(disconnected_client)
     assert heartbeat_pool.pool_size() == 1
 
-    for _ in range(4):
-        conn = heartbeat_pool.produce_client()
-        heartbeat_pool.put_back_connection(conn)
-
     time.sleep(1)
-    assert heartbeat_pool.pool_size() == 5
+    assert heartbeat_pool.pool_size() == 1
     # after check_interval, connection need check, but connection is dead
     time.sleep(2)
     # disconnection should be detected and dead clients removed (1 client may not be counted if it is being checked)
-    assert heartbeat_pool.pool_size() in (3, 4)
+    assert heartbeat_pool.pool_size() == 0
+
+    for _ in range(3):
+        conn = heartbeat_pool.produce_client()
+        heartbeat_pool.put_back_connection(conn)
+
+    time.sleep(4)
 
     # Make sure all clients have been checked
     use_counts = [client.use_count for client in heartbeat_pool.connections]

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -397,6 +397,10 @@ def test_heartbeat_client_pool(
     use_counts = [client.use_count for client in heartbeat_pool.connections]
     assert all(use_counts)
 
+    heartbeat_pool.clear()
+
+    time.sleep(1)
+
 
 def test_api_call_context(
         pingpong_thrift_client, pingpong_service_key, pingpong_thrift_service,

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -388,8 +388,8 @@ def test_heartbeat_client_pool(
     assert heartbeat_pool.pool_size() == 5
     # after check_interval, connection need check, but connection is dead
     time.sleep(2)
-    # disconnection should be detected and dead clients removed
-    assert heartbeat_pool.pool_size() == 4
+    # disconnection should be detected and dead clients removed (1 client may not be counted if it is being checked)
+    assert heartbeat_pool.pool_size() in (3, 4)
 
     # Make sure all clients have been checked
     use_counts = [client.use_count for client in heartbeat_pool.connections]

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -464,8 +464,8 @@ class HeartbeatClientPoolTest(_AsyncTestCase):
         self.assertEqual(heartbeat_pool.pool_size(), 5)
         # after check_interval, connection need check, but connection is dead
         yield gen.sleep(2)
-        # disconnection should be detected and dead clients removed
-        self.assertEqual(heartbeat_pool.pool_size(), 4)
+        # disconnection should be detected and dead clients removed (1 client may not be counted if it is being checked)
+        self.assertIn(heartbeat_pool.pool_size(), (3, 4))
 
         # Make sure all clients have been checked
         use_counts = [client.use_count for client in heartbeat_pool.connections]

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -473,6 +473,10 @@ class HeartbeatClientPoolTest(_AsyncTestCase):
         use_counts = [client.use_count for client in heartbeat_pool.connections]
         self.assertTrue(all(use_counts))
 
+        heartbeat_pool.clear()
+
+        yield gen.sleep(1)
+
 
 @pytest.mark.usefixtures('tornado_pingpong_thrift_client')
 class APICallContextTest(_AsyncTestCase):

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -428,7 +428,7 @@ class RoundRobinMultiServerClientTest(_AsyncTestCase):
 
 @pytest.mark.usefixtures('tornado_pingpong_thrift_client')
 class HeartbeatClientPoolTest(_AsyncTestCase):
-    @tornado.testing.gen_test
+    @tornado.testing.gen_test(timeout=10)
     def test_heartbeat_client_pool(self):
         from thrift_connector.tornado import TornadoHeartbeatClientPool
         heartbeat_pool = TornadoHeartbeatClientPool(
@@ -438,7 +438,7 @@ class HeartbeatClientPoolTest(_AsyncTestCase):
             name=self.pingpong_thrift_client.pool.name,
             timeout=1,
             connection_class=self.pingpong_thrift_client.pool.connection_class,
-            max_conn=5,
+            max_conn=3,
             check_interval=2,
         )
 
@@ -456,16 +456,18 @@ class HeartbeatClientPoolTest(_AsyncTestCase):
         self.assertTrue(heartbeat_pool.put_back_connection(disconnected_client))
         self.assertEqual(heartbeat_pool.pool_size(), 1)
 
-        for _ in range(4):
-            conn = heartbeat_pool.produce_client()
-            heartbeat_pool.put_back_connection(conn)
-
         yield gen.sleep(1)
-        self.assertEqual(heartbeat_pool.pool_size(), 5)
+        self.assertEqual(heartbeat_pool.pool_size(), 1)
         # after check_interval, connection need check, but connection is dead
         yield gen.sleep(2)
         # disconnection should be detected and dead clients removed (1 client may not be counted if it is being checked)
-        self.assertIn(heartbeat_pool.pool_size(), (3, 4))
+        self.assertEqual(heartbeat_pool.pool_size(), 0)
+
+        for _ in range(3):
+            conn = heartbeat_pool.produce_client()
+            heartbeat_pool.put_back_connection(conn)
+
+        yield gen.sleep(4)
 
         # Make sure all clients have been checked
         use_counts = [client.use_count for client in heartbeat_pool.connections]

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -1,0 +1,558 @@
+import contextlib
+import random
+import signal
+import subprocess
+import time
+
+import os
+import pytest
+import tornado.testing
+
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
+
+from datetime import timedelta
+from tornado import gen
+from tornado.concurrent import Future
+from tornado.ioloop import IOLoop
+
+from pingpong_app.fixtures import TestServerInfo
+
+
+@contextlib.contextmanager
+def fake_datetime(fake_time):
+    def fake(*args):
+        return fake_time
+
+    ori_method = getattr(time, 'time')
+    setattr(time, 'time', fake)
+    try:
+        yield
+    finally:
+        setattr(time, 'time', ori_method)
+
+
+@pytest.fixture(scope='session')
+def tornado_pingpong_thrift_server(request):
+    port = random.randint(25536, 35536)
+    port2 = random.randint(15536, 25536)
+    config_path = "examples/gunicorn_config.py"
+    gunicorn_server = subprocess.Popen(
+        ["gunicorn_thrift", "examples.pingpong_app.app:app",
+         "-c", config_path, "--bind", "0.0.0.0:%s" % port,
+         "--bind", "0.0.0.0:%s" % port2, '--thrift-transport-factory', 'thriftpy.transport:TFramedTransportFactory']
+    )
+
+    def shutdown():
+        os.kill(gunicorn_server.pid, signal.SIGTERM)
+
+    request.addfinalizer(shutdown)
+    time.sleep(4)
+
+    return port, port2, gunicorn_server
+
+
+@pytest.fixture(scope='class')
+def tornado_pingpong_thrift_client(request, pingpong_service_key,
+                                   pingpong_thrift_service, tornado_pingpong_thrift_server):
+    port, port2, gunicorn_server = tornado_pingpong_thrift_server
+
+    from thrift_connector.tornado import TornadoClientPool, TornadoThriftPyClient
+
+    pool = TornadoClientPool(
+        pingpong_thrift_service,
+        'localhost',
+        port,
+        name=pingpong_service_key,
+        connection_class=TornadoThriftPyClient
+    )
+
+    request.cls.pingpong_thrift_client = TestServerInfo(
+        'localhost',
+        port,
+        gunicorn_server,
+        pool,
+        pingpong_thrift_service,
+        port2=port2
+    )
+
+
+class _AsyncTestCase(tornado.testing.AsyncTestCase):
+    def get_new_ioloop(self):
+        return IOLoop.instance()
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class ClientPoolTest(_AsyncTestCase):
+    def _cleanup_pool(self):
+        pool = self.pingpong_thrift_client.pool
+        for c in pool.connections:
+            c.close()
+        pool.connections = pool.QueueCls()
+
+    def setUp(self):
+        super(ClientPoolTest, self).setUp()
+        self._cleanup_pool()
+
+    def tearDown(self):
+        super(ClientPoolTest, self).tearDown()
+        self._cleanup_pool()
+
+    @tornado.testing.gen_test
+    def test_client_pool(self):
+        old_client = None
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+            old_client = c
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+            self.assertIs(c, old_client)
+
+    @tornado.testing.gen_test
+    def test_client_pool_dead_connection_occured(self):
+        os.kill(self.pingpong_thrift_client.process.pid, signal.SIGHUP)  # restart
+        time.sleep(1)
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+            old_client = c
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+            self.assertIs(c, old_client)
+
+    @tornado.testing.gen_test
+    def test_client_pool_disabled(self):
+        pool = self.pingpong_thrift_client.pool
+        pool.max_conn = 0
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+            old_client = c
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+            self.assertIsNot(c, old_client)
+
+    @tornado.testing.gen_test
+    def test_client_pool_overflow(self):
+        from thriftpy.transport import TTransportException
+        from thrift_connector.tornado import TornadoClientPool
+
+        pool = self.pingpong_thrift_client.pool
+        pool.max_conn = 3
+
+        ori_method = getattr(TornadoClientPool, 'get_client_from_pool')
+
+        def mock_method(*args):
+            future = Future()
+            future.set_result(None)
+            return future
+
+        setattr(TornadoClientPool, 'get_client_from_pool', mock_method)
+        try:
+            available_clients = []
+            for _ in range(5):
+                with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+                    yield c.ping()
+                    available_clients.append(c)
+
+            pool = self.pingpong_thrift_client.pool
+            self.assertLessEqual(len(pool.connections), pool.max_conn)
+
+            for n, c in enumerate(available_clients[:pool.max_conn]):
+                if n > pool.max_conn - 1:
+                    # Overflown connections should be closed after use.
+                    try:
+                        yield c.ping()
+                    except TTransportException:
+                        pass
+                    else:
+                        self.fail('Overflown connections should be closed after use')
+                else:
+                    yield c.ping()
+        finally:
+            setattr(TornadoClientPool, 'get_client_from_pool', ori_method)
+
+    @tornado.testing.gen_test
+    def test_client_call_and_put_back(self):
+        pool = self.pingpong_thrift_client.pool
+
+        yield pool.ping()
+        yield pool.ping()
+        yield pool.ping()
+
+        self.assertEqual(len(pool.connections), 1)
+        conn = list(pool.connections)[0]
+
+        for c in pool.connections:
+            c.close()
+
+        yield pool.ping()
+        yield pool.ping()
+        yield pool.ping()
+
+        self.assertEqual(len(pool.connections), 1)
+        self.assertIsNot(conn, list(pool.connections)[0])
+
+    @tornado.testing.gen_test
+    def test_ttronsport_exception_not_put_back(self):
+        pool = self.pingpong_thrift_client.pool
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+
+        self.assertEqual(len(pool.connections), 1)
+
+        # If TTransportException occurs, conn shouldn't be put back into pool.
+        from thriftpy.transport import TTransportException
+        try:
+            with (yield self.pingpong_thrift_client.pool.connection_ctx()):
+                raise TTransportException
+        except TTransportException:
+            pass
+        else:
+            self.fail('TTransportException should be re-raised')
+
+        self.assertEqual(len(pool.connections), 0)
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+            old_client = c
+
+        self.assertEqual(len(pool.connections), 1)
+
+        # If predefined exception occurs, conn should be put back and available.
+        try:
+            with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+                raise self.pingpong_thrift_client.service.AboutToShutDownException
+        except self.pingpong_thrift_client.service.AboutToShutDownException:
+            pass
+        else:
+            self.fail('Predefined exception should be raised')
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            self.assertIs(c, old_client)
+            yield c.ping()
+
+    @tornado.testing.gen_test
+    def test_should_not_put_back_connection_if_ttransport_exception_raised(self):
+        pool = self.pingpong_thrift_client.pool
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+
+        self.assertEqual(len(pool.connections), 1)
+
+        def should_fail_api():
+            future = Future()
+            future.set_exception(c.TTransportException())
+            return future
+
+        c.should_fail_api = should_fail_api
+
+        # If TTransportException occurs, conn shouldn't be put back into pool.
+        try:
+            yield pool.should_fail_api()
+        except c.TTransportException:
+            pass
+        else:
+            self.fail('TTransportException should be re-raised')
+
+        self.assertEqual(len(pool.connections), 0)
+
+        with (yield self.pingpong_thrift_client.pool.connection_ctx()) as c:
+            yield c.ping()
+
+        self.assertEqual(len(pool.connections), 1)
+
+        def should_fail_api():
+            future = Future()
+            future.set_exception(self.pingpong_thrift_client.service.AboutToShutDownException())
+            return future
+
+        c.should_fail_api = should_fail_api
+
+        # If predefined exception occurs, conn should be put back and available.
+        try:
+            yield pool.should_fail_api()
+        except self.pingpong_thrift_client.service.AboutToShutDownException:
+            pass
+        else:
+            self.fail('Predefined exception should be raised')
+
+        self.assertEqual(len(pool.connections), 1)
+        self.assertEqual(list(pool.connections)[0], c)
+        yield pool.ping()
+
+    @tornado.testing.gen_test
+    def test_setted_connection_pool_connection_keepalive(self):
+        keep_alive = 1
+        from thrift_connector.tornado import TornadoClientPool
+        pool = TornadoClientPool(
+            self.pingpong_thrift_client.pool.service,
+            self.pingpong_thrift_client.host,
+            self.pingpong_thrift_client.port,
+            name=self.pingpong_thrift_client.pool.name,
+            raise_empty=False, max_conn=3,
+            connection_class=self.pingpong_thrift_client.pool.connection_class,
+            keepalive=keep_alive
+        )
+        self.assertEqual(pool.keepalive, keep_alive)
+        with (yield pool.connection_ctx()) as conn:
+            now = time.time()
+            self.assertEqual(int(conn.alive_until), int(now + keep_alive))
+            self.assertTrue((yield conn.test_connection()))
+            old_connection = conn
+
+        with fake_datetime(now + 0.1):
+            with (yield pool.connection_ctx()) as conn:
+                self.assertIs(conn, old_connection)
+
+        with fake_datetime(now + keep_alive + 2):
+            self.assertFalse((yield old_connection.test_connection()))
+
+            with (yield pool.connection_ctx()) as conn:
+                self.assertIsNot(old_connection, conn)
+
+    @tornado.testing.gen_test
+    def test_not_setted_connection_pool_connection_keepalive(self):
+        from thrift_connector.tornado import TornadoClientPool
+        pool = TornadoClientPool(
+            self.pingpong_thrift_client.pool.service,
+            self.pingpong_thrift_client.host,
+            self.pingpong_thrift_client.port,
+            name=self.pingpong_thrift_client.pool.name,
+            raise_empty=False, max_conn=3,
+            connection_class=self.pingpong_thrift_client.pool.connection_class
+        )
+        self.assertIs(pool.keepalive, None)
+        with (yield pool.connection_ctx()) as conn:
+            now = time.time()
+            self.assertIs(conn.alive_until, None)
+            self.assertTrue((yield conn.test_connection()))
+            old_connection = conn
+
+        with fake_datetime(now + 0.1):
+            with (yield pool.connection_ctx()) as conn:
+                self.assertIs(conn, old_connection)
+
+        with fake_datetime(now + timedelta(days=100).seconds):
+            self.assertTrue((yield old_connection.test_connection()))
+
+            with (yield pool.connection_ctx()) as conn:
+                self.assertIs(old_connection, conn)
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class ClientPoolGenerationTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_connection_pool_generation(self):
+        pool = self.pingpong_thrift_client.pool
+        c = pool.produce_client()
+        self.assertEqual(c.pool_generation, pool.generation)
+        self.assertEqual(c.pool_generation, 0)
+
+        pool.clear()
+
+        c2 = pool.produce_client()
+        self.assertEqual(c2.pool_generation, pool.generation)
+        self.assertEqual(c2.pool_generation, 1)
+
+        pool.put_back_connection(c)
+        pool.put_back_connection(c2)
+
+        for c in pool.connections:
+            self.assertEqual(c.pool_generation, pool.generation)
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class RandomMultiServerClientTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_random_multiconnection_pool(self):
+        servers = [
+            (self.pingpong_thrift_client.host, self.pingpong_thrift_client.port),
+            (self.pingpong_thrift_client.host, self.pingpong_thrift_client.port2),
+        ]
+
+        from thrift_connector.tornado import TornadoRandomMultiServerClient
+        random_pool = TornadoRandomMultiServerClient(
+            self.pingpong_thrift_client.pool.service,
+            servers=servers,
+            name=self.pingpong_thrift_client.pool.name,
+            raise_empty=False, max_conn=3,
+            connection_class=self.pingpong_thrift_client.pool.connection_class,
+        )
+
+        with (yield random_pool.connection_ctx()) as conn:
+            self.assertTrue((yield conn.test_connection()))
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class RoundRobinMultiServerClientTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_roundrobin_multiconnection_pool(self):
+        servers = [
+            (self.pingpong_thrift_client.host, self.pingpong_thrift_client.port),
+            (self.pingpong_thrift_client.host, self.pingpong_thrift_client.port2),
+        ]
+
+        from thrift_connector.tornado import TornadoRoundRobinMultiServerClient
+        roundrobin_pool = TornadoRoundRobinMultiServerClient(
+            self.pingpong_thrift_client.pool.service,
+            servers=servers,
+            name=self.pingpong_thrift_client.pool.name,
+            raise_empty=False, max_conn=3,
+            connection_class=self.pingpong_thrift_client.pool.connection_class,
+        )
+
+        conn1 = roundrobin_pool.produce_client()
+        self.assertTrue((yield conn1.test_connection()))
+
+        conn2 = roundrobin_pool.produce_client()
+        self.assertTrue((yield conn2.test_connection()))
+        self.assertNotEqual((conn1.host, conn1.port), (conn2.host, conn2.port))
+
+        conn3 = roundrobin_pool.produce_client()
+        self.assertEqual((conn1.host, conn1.port), (conn3.host, conn3.port))
+        self.assertNotEqual((conn2.host, conn2.port), (conn3.host, conn3.port))
+
+        conn4 = roundrobin_pool.produce_client()
+        self.assertNotEqual((conn1.host, conn1.port), (conn4.host, conn4.port))
+        self.assertEqual((conn2.host, conn2.port), (conn4.host, conn4.port))
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class HeartbeatClientPoolTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_heartbeat_client_pool(self):
+        from thrift_connector.tornado import TornadoHeartbeatClientPool
+        heartbeat_pool = TornadoHeartbeatClientPool(
+            self.pingpong_thrift_client.pool.service,
+            self.pingpong_thrift_client.host,
+            self.pingpong_thrift_client.port,
+            name=self.pingpong_thrift_client.pool.name,
+            timeout=1,
+            connection_class=self.pingpong_thrift_client.pool.connection_class,
+            max_conn=5,
+            check_interval=2,
+        )
+
+        conn1 = yield heartbeat_pool.get_client()
+        self.assertTrue((yield conn1.test_connection()))
+
+        # now we kill client and put back to pool
+        conn1.close()
+        heartbeat_pool.put_back_connection(conn1)
+        self.assertEqual(heartbeat_pool.pool_size(), 1)
+
+        # this call should fail
+        disconnected_client = yield heartbeat_pool.get_client()
+        self.assertFalse((yield disconnected_client.test_connection()))
+        self.assertTrue(heartbeat_pool.put_back_connection(disconnected_client))
+        self.assertEqual(heartbeat_pool.pool_size(), 1)
+
+        for _ in range(4):
+            conn = heartbeat_pool.produce_client()
+            heartbeat_pool.put_back_connection(conn)
+
+        yield gen.sleep(1)
+        self.assertEqual(heartbeat_pool.pool_size(), 5)
+        # after check_interval, connection need check, but connection is dead
+        yield gen.sleep(2)
+        # disconnection should be detected and dead clients removed
+        self.assertEqual(heartbeat_pool.pool_size(), 4)
+
+        # Make sure all clients have been checked
+        use_counts = [client.use_count for client in heartbeat_pool.connections]
+        self.assertTrue(all(use_counts))
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class APICallContextTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_api_call_context(self):
+        from thrift_connector.hooks import before_call, after_call
+
+        pool = self.pingpong_thrift_client.pool
+
+        mock_before_hook = Mock()
+        mock_after_hook = Mock()
+        before_call.register(mock_before_hook)
+        after_call.register(mock_after_hook)
+
+        fake_time = time.time()
+        with fake_datetime(fake_time):
+            with (yield pool.connection_ctx()) as conn:
+                ping_future = conn.ping()
+                yield ping_future
+
+            mock_before_hook.assert_called_with(pool, conn, 'ping', fake_time)
+            mock_after_hook.assert_called_with(pool, conn, 'ping', fake_time, 0, ping_future)
+
+        # raise Exception when raises specified
+        mock_before_hook_with_err = Mock(side_effect=TypeError('test'))
+        before_call.register(mock_before_hook_with_err, raises=(TypeError,))
+        with (yield pool.connection_ctx()) as client:
+            with pytest.raises(TypeError) as exc_info:
+                yield client.win()
+
+        assert "test" in str(exc_info.value)
+        before_call.callbacks.clear()
+        after_call.callbacks.clear()
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class ConnCloseHookTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_conn_close_hook(self):
+        pool = self.pingpong_thrift_client.pool
+        close_mock = Mock()
+        pool.register_after_close_func(close_mock)
+        client = yield pool.get_client()
+        client.close()
+        close_mock.assert_called_with(pool, client)
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class SetTimeoutTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_set_timeout(self):
+        pool = self.pingpong_thrift_client.pool
+        client = yield pool.get_client()
+
+        client.set_client_timeout(0.5 * 1000)
+        self.assertEqual((yield client.sleep(0.2)), 'good morning')
+
+        with pytest.raises(client.TTransportException) as e:
+            yield client.sleep(1)
+
+        self.assertIn('type=3', str(e.value))
+        client.close()
+
+        with pytest.raises(client.TTransportException) as e:
+            with (yield pool.connection_ctx(timeout=1)) as client:
+                yield client.sleep(2)
+        self.assertIn('type=3', str(e.value))
+
+
+@pytest.mark.usefixtures('tornado_pingpong_thrift_client')
+class FillConnectionPoolTest(_AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_fill_conneciont_pool(self):
+        from thrift_connector.tornado import TornadoBaseClientPool
+        pool = TornadoBaseClientPool(
+            self.pingpong_thrift_client.pool.service,
+            connection_class=self.pingpong_thrift_client.pool.connection_class
+        )
+        self.assertEqual(pool.max_conn, 30)
+        self.assertEqual(pool.pool_size(), 0)
+        pool.yield_server = Mock(
+            return_value=(
+                self.pingpong_thrift_client.host, self.pingpong_thrift_client.port))
+        pool.fill_connection_pool()
+        self.assertEqual(pool.pool_size(), pool.max_conn)

--- a/thrift_connector/connection_pool.py
+++ b/thrift_connector/connection_pool.py
@@ -481,20 +481,6 @@ class HeartbeatClientPool(ClientPool):
         t.daemon = True
         t.start()
 
-    def _close_and_remove_client(self, client):
-        if client not in self.connections:
-            return
-
-        try:
-            self.connections.remove(client)
-            client.close()
-        except KeyError as e:
-            logger.warn('Error removing client from pool %s, %s',
-                        self.service.__name__, e)
-        except Exception as e:
-            logger.warn('Error closing client %s, %s',
-                        self.service.__name__, e)
-
     def get_client_from_pool(self):
         return self._get_connection()
 

--- a/thrift_connector/tornado.py
+++ b/thrift_connector/tornado.py
@@ -1,0 +1,359 @@
+from __future__ import absolute_import
+
+import contextlib
+import logging
+import random
+import time
+
+from datetime import timedelta
+from tornado import gen
+from tornado.concurrent import Future, is_future
+from tornado.ioloop import PeriodicCallback
+
+from thrift_connector.connection_pool import ThriftClient, BaseClientPool, ThriftPyBaseClient, \
+    ClientPool, validate_host_port
+
+logger = logging.getLogger(__name__)
+
+
+class TornadoThriftClient(ThriftClient):
+    @classmethod
+    def get_socket_factory(self):
+        return lambda host, port: [host, port]
+
+    @classmethod
+    def set_timeout(cls, socket, timeout):
+        socket[2:] = [timeout]
+
+    @classmethod
+    def get_transport_factory(self):
+        from thrift.TTornado import TTornadoStreamTransport
+        return lambda socket: TTornadoStreamTransport(socket[0], socket[1])
+
+    @classmethod
+    def get_protoco_factory(self):
+        from thrift.protocol import TBinaryProtocol
+        return lambda _: TBinaryProtocol.TBinaryProtocolFactory()
+
+    def get_tclient(self, service, protocol):
+        if self.tracking is True:
+            raise NotImplementedError(
+                "%s doesn't support tracking" % self.__class__.__name__)
+        return service.Client(self.transport, protocol)
+
+    def get_timeout(self):
+        return self.socket[2]
+
+    def test_connection(self):
+        future = Future()
+
+        if self.is_expired() or self.is_tired():
+            future.set_result(False)
+            return future
+
+        def cb(ping_future):
+            try:
+                ping_future.result()
+                future.set_result(True)
+            except:
+                future.set_result(False)
+
+        try:
+            self.ping().add_done_callback(cb)
+        except:
+            future.set_result(False)
+
+        return future
+
+
+class TornadoThriftPyClient(ThriftPyBaseClient):
+    @classmethod
+    def get_socket_factory(cls):
+        return lambda host, port: [host, port]
+
+    @classmethod
+    def set_timeout(cls, socket, timeout):
+        socket[2:] = [timeout]
+
+    @classmethod
+    def get_transport_factory(cls):
+        from thriftpy.tornado import TTornadoStreamTransport
+        return lambda socket: TTornadoStreamTransport(
+            socket[0], socket[1], read_timeout=timedelta(milliseconds=socket[2]))
+
+    @classmethod
+    def get_protoco_factory(self):
+        # These imports bypass the cython binary
+        from thriftpy.protocol.binary import TBinaryProtocolFactory
+        from thriftpy.transport.memory import TMemoryBuffer
+
+        factory = TBinaryProtocolFactory()
+        return lambda transport: (
+            factory.get_protocol(TMemoryBuffer()),
+            factory.get_protocol(transport)
+        )
+
+    def get_tclient(self, service, protocol):
+        if self.tracking is True:
+            raise NotImplementedError(
+                "%s doesn't support tracking" % self.__class__.__name__)
+
+        from thriftpy.tornado import TTornadoClient
+        return TTornadoClient(service, protocol[0], protocol[1])
+
+    def set_client_timeout(self, timeout):
+        super(TornadoThriftPyClient, self).set_client_timeout(timeout)
+
+        self.transport.read_timeout = timedelta(milliseconds=timeout)
+
+    def get_timeout(self):
+        return self.socket[2]
+
+    def test_connection(self):
+        future = Future()
+
+        if self.is_expired() or self.is_tired():
+            future.set_result(False)
+            return future
+
+        def cb(ping_future):
+            try:
+                ping_future.result()
+                future.set_result(True)
+            except:
+                future.set_result(False)
+
+        try:
+            self.ping().add_done_callback(cb)
+        except:
+            future.set_result(False)
+
+        return future
+
+
+class _ContextManagerFuture(Future):
+    """A Future that can be used with the "with" statement.
+
+    When a coroutine yields this Future, the return value is a context manager
+    that can be used like:
+
+        with (yield future) as target:
+            do_something(target)
+
+    The value returned by wrapped future will be bound to the target.
+    At the end of the block, the Future's exit callback will be invoked
+    with this value and the exception if caught.
+
+    Inspired by `toro <https://github.com/ajdavis/toro>`_. The original code is licensed under
+    Apache License, Version 2.0 (`LICENSE <https://raw.githubusercontent.com/ajdavis/toro/master/LICENSE>`_).
+    """
+
+    def __init__(self, wrapped, exit_callback):
+        super(_ContextManagerFuture, self).__init__()
+        wrapped.add_done_callback(self._done_callback)
+        self.exit_callback = exit_callback
+
+    def _done_callback(self, wrapped):
+        if wrapped.exception():
+            self.set_exc_info(wrapped.exc_info())
+        else:
+            self.set_result(wrapped.result())
+
+    def result(self, timeout=None):
+        if self.exception():
+            super(_ContextManagerFuture, self).result()
+
+        # Otherwise return a context manager that cleans up after the block.
+        @contextlib.contextmanager
+        def f():
+            try:
+                yield self._result
+            except Exception as e:
+                self.exit_callback(self._result, e)
+            else:
+                self.exit_callback(self._result, None)
+
+        return f()
+
+
+class TornadoBaseClientPool(BaseClientPool):
+    def __init__(self, *args, **kwargs):
+        super(TornadoBaseClientPool, self).__init__(*args, **kwargs)
+        self.__api_method_cache = {}
+
+    def get_client_from_pool(self):
+        future = Future()
+
+        connection = self._get_connection()
+        if connection is None:
+            future.set_result(None)
+            return future
+
+        def cb(test_future):
+            if test_future.result():
+                future.set_result(connection)
+            else:
+                connection.close()
+                future.set_result(None)
+
+        connection.test_connection().add_done_callback(cb)  # make sure old connection is usable
+
+        return future
+
+    @gen.coroutine
+    def get_client(self):
+        raise gen.Return((yield self.get_client_from_pool()) or self.produce_client())
+
+    def __getattr__(self, name):
+        method = self.__api_method_cache.get(name)
+        if not method:
+            @gen.coroutine
+            def method(*args, **kwds):
+                client = yield self.get_client()
+                api = getattr(client, name, None)
+                will_put_back = True
+                try:
+                    if api and (callable(api) or is_future(api)):
+                        raise gen.Return((yield api(*args, **kwds)))
+                    raise AttributeError("%s not found in %s" % (name, client))
+                except client.TTransportException:
+                    will_put_back = False
+                    client.close()
+                    raise
+                finally:
+                    if will_put_back:
+                        self.put_back_connection(client)
+
+            self.__api_method_cache[name] = method
+        return method
+
+    def _connection_ctx_exit_callback(self, client, exception):
+        if not exception:
+            self.put_back_connection(client)
+            return
+
+        if isinstance(exception, client.TTransportException):
+            client.close()
+            raise
+        else:
+            self.put_back_connection(client)
+            raise
+
+    def connection_ctx(self, timeout=None):
+        future = self.get_client()
+
+        if timeout is not None:
+            future.add_done_callback(lambda f: f.result().set_client_timeout(timeout * 1000))
+
+        return _ContextManagerFuture(future, self._connection_ctx_exit_callback)
+
+
+class TornadoClientPool(TornadoBaseClientPool, ClientPool):
+    pass
+
+
+class TornadoHeartbeatClientPool(TornadoClientPool):
+    def __init__(self, service, host, port, timeout=30, name=None,
+                 raise_empty=False, max_conn=30, connection_class=ThriftClient,
+                 keepalive=None, tracking=False, tracker_factory=None,
+                 use_limit=None, check_interval=10):
+        super(TornadoHeartbeatClientPool, self).__init__(
+            service=service,
+            host=host,
+            port=port,
+            timeout=timeout,
+            name=name,
+            raise_empty=raise_empty,
+            max_conn=max_conn,
+            connection_class=connection_class,
+            keepalive=keepalive,
+            tracking=tracking,
+            tracker_factory=tracker_factory,
+            use_limit=use_limit,
+        )
+        self.check_interval = check_interval
+
+        self._heartbeat_timer = PeriodicCallback(self.maintain_connections, max(1, self.timeout - 5) * 1000)
+        self._heartbeat_timer.start()
+
+    def _close_and_remove_client(self, client):
+        if client not in self.connections:
+            return
+
+        try:
+            self.connections.remove(client)
+            client.close()
+        except KeyError as e:
+            logger.warn('Error removing client from pool %s, %s',
+                        self.service.__name__, e)
+        except Exception as e:
+            logger.warn('Error closing client %s, %s',
+                        self.service.__name__, e)
+
+    def get_client_from_pool(self):
+        future = Future()
+        future.set_result(self._get_connection())
+        return future
+
+    @gen.coroutine
+    def maintain_connections(self):
+        pool_size = self.pool_size()
+        for _ in range(pool_size):
+            conn = self._get_connection()
+            if conn is None:
+                break
+
+            if time.time() - conn.latest_use_time < self.check_interval \
+                    or (yield conn.test_connection()):
+                self.put_back_connection(conn)
+            else:
+                conn.close()
+
+
+class TornadoMultiServerClientBase(TornadoBaseClientPool):
+    def __init__(self, service, servers, timeout=30, name=None,
+                 raise_empty=False, max_conn=30, connection_class=ThriftClient,
+                 keepalive=None, tracking=False, tracker_factory=None,
+                 use_limit=None):
+        super(TornadoMultiServerClientBase, self).__init__(
+            service=service,
+            timeout=timeout,
+            name=name,
+            raise_empty=raise_empty,
+            max_conn=max_conn,
+            connection_class=connection_class,
+            keepalive=keepalive,
+            tracking=tracking,
+            tracker_factory=None,
+            use_limit=use_limit,
+        )
+
+        self.servers = list(servers)
+
+    def set_servers(self, server_info):
+        for i in server_info:
+            assert len(i) == 2
+            validate_host_port(*i)
+        self.servers = server_info
+        self.clear()
+
+
+class TornadoRandomMultiServerClient(TornadoMultiServerClientBase):
+    def yield_server(self):
+        assert len(self.servers) > 0
+        return random.choice(self.servers)
+
+
+class TornadoRoundRobinMultiServerClient(TornadoMultiServerClientBase):
+    def __init__(self, *args, **kwds):
+        super(TornadoRoundRobinMultiServerClient, self).__init__(*args, **kwds)
+        self.index = random.randint(0, len(self.servers) - 1)
+        random.shuffle(self.servers)
+
+    def yield_server(self):
+        assert len(self.servers) > 0
+        if self.index >= len(self.servers):
+            self.index = 0
+        ret = self.servers[self.index]
+        self.index += 1
+        return ret

--- a/thrift_connector/tornado.py
+++ b/thrift_connector/tornado.py
@@ -276,20 +276,6 @@ class TornadoHeartbeatClientPool(TornadoClientPool):
         self._heartbeat_timer = PeriodicCallback(self.maintain_connections, max(1, self.timeout - 5) * 1000)
         self._heartbeat_timer.start()
 
-    def _close_and_remove_client(self, client):
-        if client not in self.connections:
-            return
-
-        try:
-            self.connections.remove(client)
-            client.close()
-        except KeyError as e:
-            logger.warn('Error removing client from pool %s, %s',
-                        self.service.__name__, e)
-        except Exception as e:
-            logger.warn('Error closing client %s, %s',
-                        self.service.__name__, e)
-
     def get_client_from_pool(self):
         future = Future()
         future.set_result(self._get_connection())

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,12 @@
 envlist = py{27,33,34,35}
 [testenv]
 deps =
+    cython
     gevent
     gunicorn_thrift
     thriftpy
+    tornado
+    toro
     pytest
     py27: mock
 commands = py.test tests


### PR DESCRIPTION
This PR adds Tornado support. Tornado related code is located in `thrift_connector.tornado` package and tests are located at `tests/test_tornado.py`.

#### Implemented Clients

* TornadoThriftClient - Tornado client for native thrift library
* TornadoThriftPyClient - Tornado client for thriftpy library

#### Implemented Pools

* TornadoClientPool
* TornadoHeartbeatClientPool
* TornadoRandomMultiServerClient
* TornadoRoundRobinMultiServerClient

#### Tests

All of the tests(17/17) have been ported to Tornado related clients and pools, which is located at `tests/test_tornado.py`. No extra tests are added currently.

#### Examples

2 examples are added: `tornado_thrift_client.py` and `tornado_thriftpy_client.py`. Related scripts have been updated.

#### License

Class `_ContextManagerFuture` is based on the code from [toro](https://github.com/ajdavis/toro/blob/master/toro/__init__.py#L94-L128). The original code is licensed under Apache License, Version 2.0.

#### Usage

The use of Tornado pools is straight forward.

```python
service = thriftpy.load("pingpong_app/pingpong.thrift")
pool = TornadoClientPool(
    service.PingService,
    'localhost',
    8880,
    connection_class=TornadoThriftPyClient
)


def callback(future):
    print future.result()
    IOLoop.current().stop()


@gen.coroutine
def main():
    yield pool.ping()

    with (yield pool.connection_ctx()) as conn:
        yield conn.sleep(1)

    pool.win().add_done_callback(callback)


IOLoop.current().add_callback(main)
IOLoop.current().start()

```